### PR TITLE
Fix implicit use of directory when building with command-line

### DIFF
--- a/WebAssembly/ROOT
+++ b/WebAssembly/ROOT
@@ -3,6 +3,8 @@ session WebAssembly_Dev = "HOL-Library" +
   options [quick_and_dirty]
   sessions
     Native_Word
+  directories
+    "../libs"
   theories
     Wasm
     Wasm_Ast


### PR DESCRIPTION
Building with:

```bash
isabelle build -D . -v WebAssembly_Dev
```

currently fails because theories from `WasmCert-Isabelle/libs` are used implicitly. This PR adds `../libs` as an explicit session directory dependency, fixing the build error.